### PR TITLE
Add VOD as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "deep-learning-server/connxr"]
 	path = deep-learning-server/connxr
 	url = https://github.com/mofanv/cONNXr
+[submodule "video-object-detection"]
+	path = video-object-detection
+	url = https://github.com/veracruz-project/video-object-detection
+	branch = main


### PR DESCRIPTION
Add VOD (`main` branch) as submodule.
Obsoletes https://github.com/veracruz-project/veracruz-examples/pull/4.
The `iotex` branch containing features relevant to the iotex demo (decryption) will be added as a submodule under `i-poc` (cf. https://github.com/veracruz-project/veracruz-examples/pull/7)